### PR TITLE
Added eslint:recommended

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@
 
 module.exports = {
     'extends': [
+        'eslint:recommended'
+    ].concat([
         './rules/arbitrary',
         './rules/bestPractices',
         './rules/style',
         './rules/variables'
-    ].map(require.resolve),
+    ].map(require.resolve)),
     rules: { }
 };

--- a/rules/arbitrary.js
+++ b/rules/arbitrary.js
@@ -4,6 +4,7 @@
 
 module.exports = {
     rules: {
+        'no-console':            1,
         'no-param-reassign':     1,
         'no-proto':              2,
         'no-return-assign':      [2, 'except-parens'],


### PR DESCRIPTION
This PR adds eslint:recommended by default, I'm adding `no-console: 0` to our rules so that our code is compatible with the recommended rules. The following table exposes what new non-zero rules will be incorporated:

| Name  | ESLint |
| :---      | :---    |
| no-console | 2 **(we'll override this)** |
| no-control-regex | 2 |
| no-delete-var | 2 |
| no-fallthrough | 2 |
| no-func-assign | 2 |
| no-inner-declarations | [2, "functions"] |
| no-invalid-regexp | 2 |
| no-negated-in-lhs | 2 |
| no-octal | 2 |
| no-regex-spaces | 2 |
| no-sparse-arrays | 2 |
| use-isnan | 2 |
| valid-typeof | 2 |

Fixes: #5 