### PR TITLE
Prefer lodash methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+let _ = require('lodash/fp')
+
 let eslintBuiltinRules = {
   eqeqeq: ['warn', 'always'],
   'arrow-body-style': ['error', 'as-needed'],
@@ -45,6 +47,7 @@ let lodashFpRules = {
 let lodashRules = {
   'lodash/prop-shorthand': ['error', 'always'],
   'lodash/prefer-reject': 'error',
+  'lodash/prefer-lodash-method': 1,
 }
 
 let importRules = {
@@ -81,8 +84,7 @@ module.exports = {
     es6: true,
     node: true,
   },
-  rules: Object.assign(
-    {},
+  rules: _.extend(
     eslintBuiltinRules,
     reactRules,
     lodashFpRules,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-smartprocure",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "SmartProcure's ESLint configuration",
   "scripts": {
     "lint": "eslint .",
@@ -24,6 +24,7 @@
     "eslint-plugin-lodash": "^2.4.5",
     "eslint-plugin-lodash-fp": "^2.1.3",
     "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-react": "^7.3.0"
+    "eslint-plugin-react": "^7.3.0",
+    "lodash": "^4.17.4"
   }
 }


### PR DESCRIPTION
Related issues: smartprocure/marketplace#2112

Docs for the rule:
https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/prefer-lodash-method.md

I have it as a `1` (warning) right now. I ran it locally it and even picks up lodash fp so it seems like it should do the trick?