### PR TITLE
rule to ensure alias of `flow` are not used.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ let lodashFpRules = {
   'lodash-fp/prefer-composition-grouping': 'error',
   'lodash-fp/prefer-constant': ['warn', { arrowFunctions: false }],
   'lodash-fp/prefer-get': 'warn',
+  'lodash-fp/consistent-compose': ['error', 'flow'],
 }
 
 let lodashRules = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-smartprocure",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "SmartProcure's ESLint configuration",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Error when `_.pipe`, `_.compose`, or `_.flowRight` are used.
[See doc](https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/b785321319423263af7f063305308f821a1d0fcb/docs/rules/consistent-compose.md)